### PR TITLE
Smoothing loss bug fix

### DIFF
--- a/src/bert_summarizer/models/bertsum.py
+++ b/src/bert_summarizer/models/bertsum.py
@@ -185,12 +185,12 @@ class BertSumAbsDecoder(BertLMHeadModel):
                 .contiguous()
             labels = labels[:, 1:].contiguous()
 
-            output = shifted_prediction_scores.view(-1, self.config.vocab_size)
+            pred = shifted_prediction_scores.view(-1, self.config.vocab_size)
             target = labels.view(-1)
 
             normalization = target.ne(self.config.pad_token_id).sum().item()
 
-            lm_loss = self.loss(output, target).div(float(normalization))
+            lm_loss = self.loss(pred, target).div(float(normalization))
 
         if not return_dict:
             output = (prediction_scores, None, None, None, None)

--- a/src/bert_summarizer/models/bertsum.py
+++ b/src/bert_summarizer/models/bertsum.py
@@ -188,9 +188,9 @@ class BertSumAbsDecoder(BertLMHeadModel):
             pred = shifted_prediction_scores.view(-1, self.config.vocab_size)
             target = labels.view(-1)
 
-            normalization = target.ne(self.config.pad_token_id).sum().item()
-
-            lm_loss = self.loss(pred, target).div(float(normalization))
+            num_tokens = target.ne(self.config.pad_token_id).sum()
+            normalization = num_tokens.float().item()
+            lm_loss = self.loss(pred, target).div(normalization)
 
         if not return_dict:
             output = (prediction_scores, None, None, None, None)

--- a/src/bert_summarizer/models/bertsum.py
+++ b/src/bert_summarizer/models/bertsum.py
@@ -188,9 +188,10 @@ class BertSumAbsDecoder(BertLMHeadModel):
             pred = shifted_prediction_scores.view(-1, self.config.vocab_size)
             target = labels.view(-1)
 
-            num_tokens = target.ne(self.config.pad_token_id).sum()
-            normalization = num_tokens.float().item()
-            lm_loss = self.loss(pred, target).div(normalization)
+            valid_positions = target.ne(self.config.pad_token_id)
+            pred = pred[valid_positions]
+            target = target[valid_positions]
+            lm_loss = self.loss(pred, target)
 
         if not return_dict:
             output = (prediction_scores, None, None, None, None)

--- a/src/bert_summarizer/models/bertsum.py
+++ b/src/bert_summarizer/models/bertsum.py
@@ -122,10 +122,7 @@ class BertSumAbsDecoder(BertLMHeadModel):
             config.num_hidden_layers,
             nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
         )
-        self.generator = nn.Sequential(
-            nn.Linear(config.hidden_size, config.vocab_size),
-            nn.LogSoftmax(dim=-1)
-        )
+        self.generator = nn.Linear(config.hidden_size, config.vocab_size)
 
         self.loss = LabelSmoothingLoss(
             config.vocab_size,
@@ -141,7 +138,7 @@ class BertSumAbsDecoder(BertLMHeadModel):
         self.embeddings[0] = embeddings
 
     def get_output_embeddings(self) -> nn.Module:
-        return self.generator[0]
+        return self.generator
 
     def forward(
         self,
@@ -179,7 +176,7 @@ class BertSumAbsDecoder(BertLMHeadModel):
 
         # transformers style loss calculation
         decoder_outputs = output.transpose(0, 1)
-        prediction_scores = self.generator[0](decoder_outputs)
+        prediction_scores = self.generator(decoder_outputs)
 
         lm_loss = None
         if labels is not None:
@@ -188,9 +185,7 @@ class BertSumAbsDecoder(BertLMHeadModel):
                 .contiguous()
             labels = labels[:, 1:].contiguous()
 
-            output = self.generator[1](
-                shifted_prediction_scores
-            ).view(-1, self.config.vocab_size)
+            output = shifted_prediction_scores.view(-1, self.config.vocab_size)
             target = labels.view(-1)
 
             normalization = target.ne(self.config.pad_token_id).sum().item()

--- a/tests/models/test_bertsum.py
+++ b/tests/models/test_bertsum.py
@@ -137,7 +137,7 @@ class TestBertSumAbsDecoder:
         assert model.embeddings[0] is None
 
     def test_get_output_embeddings(self, model):
-        model.generator[0] = None
+        model.generator = None
         assert model.get_output_embeddings() is None
 
     def test_embeddings_weight(self, config, model):
@@ -160,8 +160,8 @@ class TestBertSumAbsDecoder:
         assert decoder_layer.linear1.in_features == config.hidden_size
         assert decoder_layer.linear1.out_features == config.intermediate_size
 
-        assert model.generator[0].in_features == config.hidden_size
-        assert model.generator[0].out_features == config.vocab_size
+        assert model.generator.in_features == config.hidden_size
+        assert model.generator.out_features == config.vocab_size
 
     def test_loss(self, config, model):
         assert model.loss.cls == config.vocab_size


### PR DESCRIPTION
Previously we use OpenNMT's LabelSmoothingLoss class and this class ignores padding position in loss calculation.
https://github.com/OpenNMT/OpenNMT-py/blob/master/onmt/utils/loss.py#L249

On the other hand, current LabelSmoothingLoss simply calculate loss with smoothing and does not consider the padding.

This PR makes BertSumAbsDecoder to calculate loss only for valid positions.